### PR TITLE
Optimized how signalhub is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ $ npm install @geut/discovery-swarm-webrtc
 const swarm = require('@geut/discovery-swarm-webrtc')
 
 const sw = swarm({
+  hub: signalhub('application-id', ['http://yourhub.com'])
   id: 'id',
   stream: () => feed.replicate()
 })
 
-sw.join(signalhub('channel-id', ['http://yourhub.com']))
+sw.join('channel-id')
 
 sw.on('connection', peer => {
   // connected
@@ -34,14 +35,23 @@ Creates a new Swarm. Options include:
 {
   id: cuid(), // peer-id for user
   stream: stream, // stream to replicate across peers
+  hub: null, // The signalhub instance to use.
 }
 ```
 
-#### `sw.join(hub, [opts])`
+#### `sw.join(channel, [opts])`
 
-Join a channel specified by [hub](https://github.com/mafintosh/signalhub) instance.
+Join a channel specified by `channel`.
 
 The options are for the `webrtc-swarm` instance.
+
+### `sw.leave(channel)`
+
+Leaves the channel specified by `channel`, closing the `webrtc-swarm` instance.
+
+### `sw.close(cb)`
+
+Closes the swarm and invokes `cb` if it was provided.
 
 ### Events
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class DiscoverySwarmWebrtc extends EventEmitter {
     })
 
     channel.swarm.on('disconnect', (peer, id) => {
-      const info = { id, channel: channelName }
+      const info = { id, channel: channelName, type: 'webrtc' }
       channel.peers.delete(id)
       this.emit('connection-closed', peer, info)
     })

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class DiscoverySwarmWebrtc extends EventEmitter {
     const channel = {
       peers: new Map(),
       swarm: createSwarm(hub, Object.assign({}, {
-        uuid: this.id
+        uuid: this.id.toString('hex')
       }, opts))
     }
 
@@ -50,7 +50,7 @@ class DiscoverySwarmWebrtc extends EventEmitter {
     })
 
     channel.swarm.on('disconnect', (peer, id) => {
-      const info = { id, channel: channelName, type: 'webrtc' }
+      const info = { id, channel: channelName }
       channel.peers.delete(id)
       this.emit('connection-closed', peer, info)
     })

--- a/index.js
+++ b/index.js
@@ -20,11 +20,16 @@ class DiscoverySwarmWebrtc extends EventEmitter {
   }
 
   join (channelName, opts = {}) {
-    assert(channelName && typeof channelName === 'string', 'A channel name is required.')
+    assert(channelName, 'A channel name is required.')
 
     if (this.channels.has(channelName)) {
       // discovery-channel returns if you're already joined, we should to
       return
+    }
+
+    // Account for when the channel is a Buffer instance (hyperdrive.discoveryKey)
+    if(typeof channelName === 'object') {
+      channelName = channelName.toString('hex')
     }
 
     const hub = subSignalhub(this.hub, channelName)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/geut/discovery-swarm-webrtc#readme",
   "dependencies": {
     "pump": "^3.0.0",
+    "sub-signalhub": "^1.0.1",
     "webrtc-swarm": "^2.9.0"
   },
   "publishConfig": {


### PR DESCRIPTION
- Uses sub-signalhub so you only need a single hub connection that's shared across all the channels
- Added `leave()` method from discovery-swarm
- Changed the behavior when calling `join()` for the same channel more than once to be the same as discovery-channel (do nothing)

I haven't tested it yet, but this is definitely a breaking change. :P