### PR TITLE
Log fatal connection errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,6 +281,7 @@ class DiscoverySwarmWebrtc extends EventEmitter {
     }
 
     await this._disconnectPeer(peer)
+    debug('error', disconnectForError, peer.getInfo());
     this.emit('error', disconnectForError, peer.getInfo())
   }
 

--- a/index.js
+++ b/index.js
@@ -281,7 +281,7 @@ class DiscoverySwarmWebrtc extends EventEmitter {
     }
 
     await this._disconnectPeer(peer)
-    debug('error', disconnectForError, peer.getInfo());
+    debug('error', disconnectForError, peer.getInfo())
     this.emit('error', disconnectForError, peer.getInfo())
   }
 


### PR DESCRIPTION
If there is some configuration error with the swarm (the one I ran into is where webrtc is available in the browser, but not by default in Node), it can be very hard to see what the problem is because even after enabling swarm debug output there is nothing logged that will tell you there's a problem. This change adds logging for the error event which will now display if debug output is enabled, allowing easy diagnosis of the config problem.