### PR TITLE
Add command line flag to disable cookies

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -5,13 +5,14 @@ const server = require('http').createServer((_, res) => {
   res.setHeader('Content-Type', 'text/plain')
   res.end('Signal running OK\n')
 })
-const io = require('socket.io')(server)
+const argv = require('minimist')(process.argv.slice(2))
+const cookie = argv.cookie === false ? argv.cookie : 'io'
+const io = require('socket.io')(server, { cookie: argv.cookie })
 
 require('../server')({ io })
-const argv = require('minimist')(process.argv.slice(2))
 
 if (argv.help || argv.h) {
-  console.log('discovery-signal-webrtc --port|-p 4000')
+  console.log('discovery-signal-webrtc --port|-p 4000 [--no-cookie]')
   process.exit(1)
 }
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "pump": "^3.0.0",
     "simple-signal-client": "^2.3.1",
     "simple-signal-server": "^2.1.1",
-    "socket.io": "^2.2.0",
-    "socket.io-client": "^2.2.0"
+    "socket.io": "^2.3.0",
+    "socket.io-client": "^2.3.0"
   },
   "devDependencies": {
     "@geut/chan": "^2.1.1",


### PR DESCRIPTION
When running the discovery-swarm-webrtc server, the socket.io defaults set a cookie. These cookies, however, do not set `samSite` flags, causing warnings in modern browsers:

<img width="1270" alt="Screenshot 2020-04-24 at 17 59 21" src="https://user-images.githubusercontent.com/248111/80234379-5c2e3e80-8658-11ea-8908-f6503854e411.png">

This PR makes two changes:
 1. Add a `--no-cookie` option to the command line interface, that stops socket.io from setting cookies.
 2. Updates to a newer version of socket.io, which in turn uses a version of engine.io that sets cookies with `sameSite=strict`, which will suppress browser warnings: https://github.com/socketio/engine.io/releases/tag/3.4.1
